### PR TITLE
fix issue where user info requests are being sent when not logged in

### DIFF
--- a/complete-application/src/app/app.component.ts
+++ b/complete-application/src/app/app.component.ts
@@ -17,11 +17,9 @@ export class AppComponent {
 
   constructor() {
     this.isLoggedIn = this.fusionAuthService.isLoggedIn();
-    this.userInfo$ = fromPromise(this.fusionAuthService.getUserInfo());
-
-    this.fusionAuthService.getUserInfo().then(userInfo => {
-      console.log(userInfo);
-    })
+    this.userInfo$ = this.isLoggedIn
+      ? fromPromise(this.fusionAuthService.getUserInfo())
+      : new Observable<UserInfo>();
   }
 
   logout() {


### PR DESCRIPTION
This is to fix what issue #9 describes -- multiple network calls to `/me` when not logged in.
- The quickstart was sending the request regardless of logged in state, which explains the failed requests.
- The request was made once to get the user info and another was just logging the response, which explains why there were multiple calls.