### PR TITLE
15 Fix Typo in Width Property Resulting in Check Mark Not Fully Displaying

### DIFF
--- a/kickstart/css/styles.css
+++ b/kickstart/css/styles.css
@@ -310,7 +310,7 @@ input[type="checkbox"]:checked:after {
   left: .25rem;
   top: .3125rem;
   transform: rotate(-46deg);
-  width: .625 rem;
+  width: .625rem;
   display: block;
   position: absolute;
 }


### PR DESCRIPTION
### **What is this PR and why do we need it?**
Fix for the typo in the width property of the input[type="checkbox"]:checked:after in the styles.css file resulting in the checkmark not filling the checkbox properly

https://github.com/FusionAuth/fusionauth-quickstart-javascript-angular-web/issues/15

Pre-Merge Checklist (if applicable)

 - [ ] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.