### PR TITLE
17 Add Redirect Handling to Log In or Create New Account CTA

### DIFF
--- a/complete-application/src/app/home-page/home-page.component.html
+++ b/complete-application/src/app/home-page/home-page.component.html
@@ -2,7 +2,11 @@
   <div class="content-container">
     <div style="margin-bottom: 100px;">
       <h1>Welcome to Changebank</h1>
-      <p>To get started, <a (click)="login()" style="cursor: pointer">log in or create a new account</a>.</p>
+      <p>To get started,
+        <button class="button-redirect" (click)="login()" style="cursor: pointer">log in</button>
+        or
+        <button class="button-redirect" (click)="register()" style="cursor: pointer">create a new account.</button>
+      </p>
     </div>
   </div>
   <div style="flex: 0;">

--- a/complete-application/src/app/home-page/home-page.component.ts
+++ b/complete-application/src/app/home-page/home-page.component.ts
@@ -16,4 +16,7 @@ export class HomePageComponent {
   login() {
     this.fusionAuthService.startLogin();
   }
+  register() {
+    this.fusionAuthService.startRegistration();
+  }
 }

--- a/complete-application/src/styles.css
+++ b/complete-application/src/styles.css
@@ -152,3 +152,12 @@ body {
 .change-container {
   flex: 1;
 }
+
+.button-redirect {
+  background: none;
+  border: none;
+  color: #096324;
+  font-size: 18px;
+  font-family: sans-serif;
+  padding: 0;
+}


### PR DESCRIPTION
### **What is this PR and why do we need it?**
Adds handling to "log in" to redirect users to log in flow
Adds handling to "create a new account" to redirect users to register flow

We are switching from using an anchor to using a button here for accessibility purposes. There should be no visible changes to the UI and clicking the log in or create a new account buttons on the home page should respectively redirect to log in and register flow.

https://github.com/FusionAuth/fusionauth-quickstart-javascript-angular-web/issues/17
**Pre-Merge Checklist (if applicable)**

 - [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.