### PR TITLE
27 Build Out Example postLogoutRedirectUri Routing

### DIFF
--- a/complete-application/src/app/app.module.ts
+++ b/complete-application/src/app/app.module.ts
@@ -24,6 +24,14 @@ import { authGuard } from './auth-guard';
         canActivate: [authGuard(false, '/account')],
       },
       {
+        path: 'logged-out',
+        loadComponent: () =>
+          import('./home-page/home-page.component').then(
+            (m) => m.HomePageComponent
+          ),
+        canActivate: [authGuard(false, '/account')],
+      },
+      {
         path: 'account',
         loadComponent: () =>
           import('./account-page/account-page.component').then(
@@ -46,6 +54,7 @@ import { authGuard } from './auth-guard';
       clientId: 'e9fdb985-9173-4e01-9d73-ac2d60d1dc8e',
       serverUrl: 'http://localhost:9011',
       redirectUri: 'http://localhost:4200',
+      postLogoutRedirectUri: 'http://localhost:4200/logged-out',
       scope: 'openid email profile offline_access',
       shouldAutoRefresh: true,
     }),

--- a/kickstart/kickstart.json
+++ b/kickstart/kickstart.json
@@ -2,6 +2,7 @@
   "variables": {
     "allowedOrigin": "http://localhost:4200",
     "authorizedRedirectURL": "http://localhost:4200",
+    "authorizedPostLogoutURL": "http://localhost:4200/logged-out",
     "authorizedOriginURL": "http://localhost:4200",
     "logoutURL": "http://localhost:4200",
     "applicationId": "e9fdb985-9173-4e01-9d73-ac2d60d1dc8e",
@@ -90,6 +91,7 @@
           "name": "Example app",
           "oauthConfiguration": {
             "authorizedRedirectURLs": [
+              "#{authorizedPostLogoutURL}",
               "#{authorizedRedirectURL}"
             ],
             "authorizedOriginURLs": [


### PR DESCRIPTION
### What is this PR and why do we need it?
The current implementation of `postLogoutRedirectUri` could benefit from a more illustrative example for users. This PR adds routing that demonstrates the behavior expected when the `postLogoutRedirectUri` is defined vs undefined.

https://github.com/FusionAuth/fusionauth-quickstart-javascript-angular-web/issues/27

To Test:

1. Login and Logout in the quickstart application observing the url on logout, this should redirect to `/logged-out`.
2. Comment out the `postLogoutRedirectUri` in the `main.tsx` file and restart the server
3. Repeat step one and ensure the redirect on log out goes to `/` as defined in the `redirectUri`

Pre-Merge Checklist (if applicable)
[x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.